### PR TITLE
Improve compatibility with AXI4 specification

### DIFF
--- a/rtl/adbg_axi_biu.sv
+++ b/rtl/adbg_axi_biu.sv
@@ -526,8 +526,10 @@ module adbg_axi_biu
       end
       S_AXIADDR:
       begin
-        if (wr_reg)
+        if (wr_reg) begin
           axi_master_aw_valid = 1'b1;
+          axi_master_w_valid  = 1'b1;
+        end
         else
           axi_master_ar_valid = 1'b1;
         if (wr_reg && axi_master_aw_ready)

--- a/rtl/adbg_axi_biu.sv
+++ b/rtl/adbg_axi_biu.sv
@@ -532,8 +532,10 @@ module adbg_axi_biu
         end
         else
           axi_master_ar_valid = 1'b1;
-        if (wr_reg && axi_master_aw_ready)
+        if (wr_reg && axi_master_aw_ready && !axi_master_w_ready)
           next_fsm_state = S_AXIDATA;
+        else if (wr_reg && axi_master_aw_ready && axi_master_w_ready)
+          next_fsm_state = S_AXIRESP;
         else if (!wr_reg && axi_master_ar_ready)
           next_fsm_state = S_AXIRESP;
       end


### PR DESCRIPTION
The debug bridge is not fully compliant with the AXI specification in that it does not support a slave waiting for WVALID before asserting AWREADY. This fix asserts WVALID together with AWVALID in writes and should fix the issue.

See https://github.com/pulp-platform/pulpino/issues/182.